### PR TITLE
Add file .travis.yml for continuous integration using travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: C
+compiler: gcc
+script: autoreconf -vsi && ./configure --enable-openssl-install && make && LD_LIBRARY_PATH=src/openssl/ src/eactest
+


### PR DESCRIPTION
Add a basic .travis.yml for automated build testing using https://travis-ci.org

The current configuration only does a very basic build using gcc and the --enable-openssl-install configure switch. More build configurations and testing tools can easily be added later.
