### PR TITLE
Add two Parameters to the autoconf and automake scripts for building the go bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: C
 compiler: gcc
 before_install: sudo apt-get update
-install: sudo apt-get install swig python-dev
+install: sudo apt-get install swig python-dev golang-go gccgo
 env:
     - CONF="--enable-openssl-install"
     - CONF="--enable-openssl-install --enable-python"
+    - CONF="--enable-openssl-install --enable-go" GCCGOFLAGS="-static-libgcc" SWIGGOPARAMS=" "
 script: autoreconf -vsi && ./configure $CONF && make && make check

--- a/bindings/go/Makefile.am
+++ b/bindings/go/Makefile.am
@@ -18,16 +18,16 @@ libgeac_la_CFLAGS  = -I$(top_srcdir)/src $(CRYPTO_CFLAGS)
 libgeac_la_LDFLAGS = $(top_builddir)/src/libeac.la $(CRYPTO_LIBS)
 
 $(BUILT_SOURCES): $(INTERFACES)
-	$(SWIG) -go -gccgo -intgosize 32 -outdir $(builddir) -I$(srcdir)/.. eac.i
+	$(SWIG) $(SWIGGOPARAMS) -go -gccgo -outdir $(builddir) -I$(srcdir)/.. eac.i
 
 eac.o: $(BUILT_SOURCES)
-	$(GCCGO) -c eac.go
+	$(GCCGO) -c eac.go $(GCCGOFLAGS)
 
 example.o: $(srcdir)/example.go
-	$(GCCGO) -c $(srcdir)/example.go
+	$(GCCGO) -c $(srcdir)/example.go $(GCCGOFLAGS)
 
 example: example.o eac.o
-	$(GCCGO) example.o eac.o libgeac_la-eac_wrap.o $(top_builddir)/src/.libs/libeac.a $(CRYPTO_LIBS) -o example
+	$(GCCGO) example.o eac.o libgeac_la-eac_wrap.o $(top_builddir)/src/.libs/libeac.a $(CRYPTO_LIBS) $(GCCGOFLAGS) -o example
 
 libgeac_la-local: $(BUILT_SOURCES)
 

--- a/configure.ac
+++ b/configure.ac
@@ -181,12 +181,18 @@ AM_CONDITIONAL(RUBY_ENABLED, [test x"$enable_ruby" = "xyes"])
 
 if test x"$enable_go" = "xyes"
 then
+    AC_ARG_VAR([GCCGOFLAGS], [Go compiler flags])
+    AC_ARG_VAR([SWIGGOPARAMS], [Parameters passed to swig for creating the go bindings])
     AC_PATH_PROG([GCCGO],
                   [gccgo],
                   [not found])
     if test "${GCCGO}" = "not found"
     then
         AC_MSG_ERROR([go tools required to build bindings.])
+    fi
+    if test -z "${SWIGGOPARAMS}"
+    then
+        SWIGGOPARAMS="-intgosize 32"
     fi
 fi
 AM_CONDITIONAL(GO_ENABLED, [test x"$enable_go" = "xyes"])
@@ -273,4 +279,6 @@ Ruby Bindings:           ${enable_ruby}
 RUBY:                    ${RUBY}
 Go Bindings:             ${enable_go}
 gccgo:                   ${GCCGO}
+GCCGOFLAGS:              ${GCCGOFLAGS}
+SWIGGOPARAMS:            ${SWIGGOPARAMS}
 EOF


### PR DESCRIPTION
The parameter GCCGOFLAGS can be used to pass parameters to gccgo, the
SWIGGOPARAMS parameter can be used to pass parameters to swig for
building the go bindings. SWIGGOPARAMS defaults to "-intgosize 32",
GCCGOFLAGS is empty by default. Both Paramters are required for building
the bindings under Ubuntu 12.04.

Also added a travis-ci test for the go bindings.
