### PR TITLE
Fix Travis-CI Status icon

### DIFF
--- a/doc/index.txt
+++ b/doc/index.txt
@@ -11,7 +11,8 @@
 Welcome to OpenPACE's documentation!
 ###############################################################################
 
-.. image:: https://travis-ci.org/frankmorgner/openpace.png?branch=master   :target: https://travis-ci.org/frankmorgner/openpace
+.. image:: https://travis-ci.org/frankmorgner/openpace.png?branch=master
+  :target: https://travis-ci.org/frankmorgner/openpace
 
 .. sidebar:: Summary
 

--- a/doc/index.txt.in
+++ b/doc/index.txt.in
@@ -11,6 +11,9 @@
 Welcome to @PACKAGE_NAME@'s documentation!
 ###############################################################################
 
+.. image:: https://travis-ci.org/frankmorgner/openpace.png?branch=master
+  :target: https://travis-ci.org/frankmorgner/openpace
+
 .. sidebar:: Summary
 
     @PACKAGE_SUMMARY@


### PR DESCRIPTION
The Travis-CI status icon didn't get rendered correctly (status was always build unknown) and the link was missing in the index.txt.in file.
