### PR TITLE
allow developer to provide raw secret

### DIFF
--- a/src/pace_lib.c
+++ b/src/pace_lib.c
@@ -129,10 +129,10 @@ encoded_secret(const PACE_SEC * pi)
         case PACE_PUK:
         case PACE_CAN:
         case PACE_PIN:
-        case PACE_RAW:
             if (!is_char_str((unsigned char*) pi->mem->data, (size_t) pi->mem->length))
                 return NULL;
 
+        case PACE_RAW:
             out = BUF_MEM_create_init(pi->mem->data, pi->mem->length);
             break;
 


### PR DESCRIPTION
I'm working on variant of [Universal electronic card](http://en.wikipedia.org/wiki/Universal_electronic_card), it has [three rows](http://en.wikipedia.org/wiki/Machine-readable_passport). I'll improve encoded_mrz method in the future to make it understand three-rows mrz, but this patch allow library users to use openpace as is.