### PR TITLE
Add documentation for using vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     sudo apt-get update
     sudo apt-get install -y build-essential autotools-dev autoconf libtool pkg-config git xutils-dev gengetopt help2man swig python-dev openjdk-7-jdk openjdk-7-jre-headless ruby-dev golang-go gccgo
-    cd /vagrant
+    ln -s /vagrant /home/vagrant/openpace
+    cd /home/vagrant/openpace
     autoreconf -vis
     ./configure --enable-openssl-install --enable-python --enable-java --enable-ruby --enable-go GCCGOFLAGS="-static-libgcc -static-libgo"
     make

--- a/doc/install.txt.in
+++ b/doc/install.txt.in
@@ -70,15 +70,16 @@ be installed along with the language's toolchain to build the bindings.
 Setting up a development or test environment using vagrant
 ==========================================================
 
-The easiest way to setup a development or test environment is to use vagrant.
-OpenPACE comes with a Vagrantfile which let's you setup a working environment
-with just one command. All you need to do is type `vagrant up` in the OpenPACE
-directory. vagrant then sets up a Ubuntu based virtual machine, installs all
-dependencies and configures OpenPACE. You then need to `vagrant ssh` in order
-to access the VM. The `openpace` folder is shared between the host and the VM
-so any changes you make on the host are immidiately visible in the VM and vice
-versa.
-
+The easiest way to setup a development or test environment is to use `vagrant
+<https://www.vagrantup.com>`_. @PACKAGE_NAME@ comes with a Vagrantfile which
+let's you setup a working environment with just one command. All you need to do
+is type `vagrant up` in the @PACKAGE_NAME@ directory. vagrant then sets up a
+Ubuntu based virtual machine, installs all dependencies and configures
+@PACKAGE_NAME@. You then need to `vagrant ssh` in order to access the VM. The
+`openpace` folder is shared between the host and the VM so any changes you
+make on the host are immediately visible in the VM and vice versa. In order to
+use vagrant you need to install vagrant and virtualbox. Both are available via
+the repositories of most linux distributions.
 
 ===============================================================================
 Cross compiling @PACKAGE_NAME@

--- a/doc/install.txt.in
+++ b/doc/install.txt.in
@@ -66,6 +66,20 @@ You need to explicitely configure @PACKAGE_NAME@ to install them by using
 :option:`--enable-python`, :option:`--enable-java`, ... This requires SWIG to
 be installed along with the language's toolchain to build the bindings.
 
+==========================================================
+Setting up a development or test environment using vagrant
+==========================================================
+
+The easiest way to setup a development or test environment is to use vagrant.
+OpenPACE comes with a Vagrantfile which let's you setup a working environment
+with just one command. All you need to do is type `vagrant up` in the OpenPACE
+directory. vagrant then sets up a Ubuntu based virtual machine, installs all
+dependencies and configures OpenPACE. You then need to `vagrant ssh` in order
+to access the VM. The `openpace` folder is shared between the host and the VM
+so any changes you make on the host are immidiately visible in the VM and vice
+versa.
+
+
 ===============================================================================
 Cross compiling @PACKAGE_NAME@
 ===============================================================================


### PR DESCRIPTION
Add a bit of documentation for using vagrant to setup a development or testing environment. Also add a symlink to the shared folder in the vagrant environment.