### PR TITLE
don't use API that's deprecated in OpenSSL 1.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ else
                          [AC_MSG_RESULT([yes])],
                          [AC_MSG_ERROR([Need OpenSSL with SHA-256 support])])
         # check for functions of OpenSSL 1.1.0 and later
-        AC_CHECK_FUNCS(RSA_set0_key RSA_get0_key DH_set0_key DH_get0_key DH_set0_pqg DH_get0_pqg ECDSA_SIG_set0 ECDSA_SIG_get0 ASN1_STRING_get0_data)
+        AC_CHECK_FUNCS(RSA_set0_key RSA_get0_key DH_set0_key DH_get0_key DH_set0_pqg DH_get0_pqg ECDSA_SIG_set0 ECDSA_SIG_get0 ASN1_STRING_get0_data EC_POINT_get_affine_coordinates EC_POINT_set_affine_coordinates)
         LIBS="$saved_LIBS"
     fi
 fi

--- a/src/eac_util.c
+++ b/src/eac_util.c
@@ -789,7 +789,7 @@ Comp(EVP_PKEY *key, const BUF_MEM *pub, BN_CTX *bn_ctx, EVP_MD_CTX *md_ctx)
             if(!ecp || !x || !y
                     || !EC_POINT_oct2point(group, ecp,
                         (unsigned char *) pub->data, pub->length, bn_ctx)
-                    || !EC_POINT_get_affine_coordinates_GF2m(group, ecp, x, y, bn_ctx))
+                    || !EC_POINT_get_affine_coordinates(group, ecp, x, y, bn_ctx))
                 goto err;
 
             out = BUF_MEM_create(BN_num_bytes(x));

--- a/src/pace_mappings.c
+++ b/src/pace_mappings.c
@@ -447,7 +447,7 @@ ecdh_im_compute_key(PACE_CTX * ctx, const BUF_MEM * s, const BUF_MEM * in,
     g = EC_POINT_new(EC_KEY_get0_group(ephemeral_key));
     if (!g)
         goto err;
-    if (!EC_POINT_set_affine_coordinates_GFp(EC_KEY_get0_group(ephemeral_key), g,
+    if (!EC_POINT_set_affine_coordinates(EC_KEY_get0_group(ephemeral_key), g,
             x, y, bn_ctx))
         goto err;
 

--- a/src/ssl_compat.c
+++ b/src/ssl_compat.c
@@ -7,6 +7,7 @@
 #include <openssl/ecdsa.h>
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+#include <openssl/ec.h>
 #include <string.h>
 
 #ifndef HAVE_DH_SET0_KEY
@@ -166,5 +167,19 @@ void *OPENSSL_zalloc(size_t num)
         memset(out, 0, num);
 
     return out;
+}
+#endif
+
+#ifndef EC_POINT_GET_AFFINE_COORDINATES
+int EC_POINT_get_affine_coordinates(const EC_GROUP *group, const EC_POINT *p, BIGNUM *x, BIGNUM *y, BN_CTX *ctx)
+{
+    return EC_POINT_get_affine_coordinates_GF2m(group, p, x, y, ctx);
+}
+#endif
+
+#ifndef EC_POINT_SET_AFFINE_COORDINATES
+int EC_POINT_set_affine_coordinates(const EC_GROUP *group, EC_POINT *p, const BIGNUM *x, const BIGNUM *y, BN_CTX *ctx)
+{
+    return EC_POINT_set_affine_coordinates_GFp(group, p, x, y, ctx);
 }
 #endif

--- a/src/ssl_compat.h
+++ b/src/ssl_compat.h
@@ -43,10 +43,18 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
 #endif
 
-#ifndef HAVE_ASN1_STRING_get0_data
+#ifndef HAVE_ASN1_STRING_GET0_DATA
 const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);
 #endif
 
 #if !defined(HAVE_DECL_OPENSSL_ZALLOC) || HAVE_DECL_OPENSSL_ZALLOC == 0
 void *OPENSSL_zalloc(size_t num);
+#endif
+
+#ifndef EC_POINT_GET_AFFINE_COORDINATES
+int EC_POINT_get_affine_coordinates(const EC_GROUP *group, const EC_POINT *p, BIGNUM *x, BIGNUM *y, BN_CTX *ctx);
+#endif
+
+#ifndef EC_POINT_SET_AFFINE_COORDINATES
+int EC_POINT_set_affine_coordinates(const EC_GROUP *group, EC_POINT *p, const BIGNUM *x, const BIGNUM *y, BN_CTX *ctx);
 #endif


### PR DESCRIPTION
fixes https://github.com/frankmorgner/openpace/issues/37