### PR TITLE
Fixes build problem of OpenSCToken #26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "KOfJHBqx3I7GsY6OIiqBMN5iFkTpeGlj+WwXF/ZaGmG7bYtIx1641mH43ECoaxGH6I4Tkdf2VBX3xTSVaCeT8OO0K3Zr84MRqmfjfzTo1uGkwiZD3e/pahPVjOTb+IGPForskeooix6KgCJQfW6skh8EEy7EPnZTNXJw2XLujj4="
     - COVERITY_SCAN_BRANCH_PATTERN="(master|coverity.*)"
-    - COVERITY_SCAN_NOTIFICATION_EMAIL="frankmorgner@gmail.com"
+    - COVERITY_SCAN_NOTIFICATION_EMAIL="uri@mit.edu"
     - COVERITY_SCAN_BUILD_COMMAND="make"
     - COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
     - SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -102,6 +102,7 @@ cvc-create.1: cvc-create.ggo.in
 	$(ENV) $(HELP2MAN) \
 		--output=$@ \
 		--no-info \
+		--no-discard-stderr \
 		--source='$(PACKAGE_STRING)' \
 		$(builddir)/cvc-create$(EXEEXT)
 
@@ -110,6 +111,7 @@ cvc-print.1: cvc-print.ggo.in
 	$(ENV) $(HELP2MAN) \
 		--output=$@ \
 		--no-info \
+		--no-discard-stderr \
 		--source='$(PACKAGE_STRING)' \
 		$(builddir)/cvc-print$(EXEEXT)
 


### PR DESCRIPTION
Apparently, `cvc-create --help` outputs to `stderr`. The added `no-discard-stderr` flag makes sure `help2man` completes successfully. 

Resolves https://github.com/frankmorgner/OpenSCToken/issues/26