### PR TITLE
src/Makefile.am: Fix race condition in parallel builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,16 +97,14 @@ ENV = env \
 
 endif
 
-cvc-create.1: cvc-create.ggo.in
-	make -C $(builddir) cvc-create$(EXEEXT)
+cvc-create.1: cvc-create$(EXEEXT)
 	$(ENV) $(HELP2MAN) \
 		--output=$@ \
 		--no-info \
 		--source='$(PACKAGE_STRING)' \
 		$(builddir)/cvc-create$(EXEEXT)
 
-cvc-print.1: cvc-print.ggo.in
-	make -C $(builddir) cvc-print$(EXEEXT)
+cvc-print.1: cvc-print$(EXEEXT)
 	$(ENV) $(HELP2MAN) \
 		--output=$@ \
 		--no-info \


### PR DESCRIPTION
Calling "make" from a Makefile results in several make invocations
in parallel that do not know about each other and might generate
the same files in parallel:
https://buildd.debian.org/status/logs.php?pkg=openpace&ver=1.1.2%2Bds%2Bgit20220117%2B453c3d6b03a0-1

Just tell make about the correct dependencies and everything works
automatically.